### PR TITLE
Extract type from property's default value

### DIFF
--- a/Tests/Extractor/ReflectionExtractorTest.php
+++ b/Tests/Extractor/ReflectionExtractorTest.php
@@ -214,6 +214,25 @@ class ReflectionExtractorTest extends TestCase
     }
 
     /**
+     * @dataProvider defaultValueProvider
+     */
+    public function testExtractWithDefaultValue($property, $type)
+    {
+        $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue', $property, array()));
+    }
+
+    public function defaultValueProvider()
+    {
+        return array(
+            array('defaultInt', array(new Type(Type::BUILTIN_TYPE_INT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue'))),
+            array('defaultFloat', array(new Type(Type::BUILTIN_TYPE_FLOAT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue'))),
+            array('defaultString', array(new Type(Type::BUILTIN_TYPE_STRING, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue'))),
+            array('defaultArray', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue'))),
+            array('defaultNull', array(new Type(Type::BUILTIN_TYPE_NULL, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue'))),
+        );
+    }
+
+    /**
      * @dataProvider getReadableProperties
      */
     public function testIsReadable($property, $expected)

--- a/Tests/Fixtures/DefaultValue.php
+++ b/Tests/Fixtures/DefaultValue.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * @author Tales Santos <tales.augusto.santos@gmail.com>
+ */
+class DefaultValue
+{
+    public $defaultInt = 30;
+
+    public $defaultFloat = 30.5;
+
+    public $defaultString = 'foo';
+
+    public $defaultArray = [];
+
+    public $defaultNull = null;
+}


### PR DESCRIPTION
This PR ables the ReflectionExtractor to extract built-in type from default value of properties.


Q | A
-- | --
Branch? | master
Bug fix? | no
New feature? | yes
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets | -
License | MIT
Doc PR | -

