### PR TITLE
Fix undefined variable fromConstructor when passing context to getTypes

### DIFF
--- a/Extractor/ReflectionExtractor.php
+++ b/Extractor/ReflectionExtractor.php
@@ -118,7 +118,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         }
 
         if (
-            $context['enable_constructor_extraction'] ?? $this->enableConstructorExtraction &&
+            ($context['enable_constructor_extraction'] ?? $this->enableConstructorExtraction) &&
             $fromConstructor = $this->extractFromConstructor($class, $property)
         ) {
             return $fromConstructor;


### PR DESCRIPTION
If passing context to getTypes, it checks value of $context['enable_constructor_extraction']  for true/false or the constructor value of enableConstructorExtraction and should then populate fromConstructor if necessary. The missing brackets around the first part of this check mean that fromConstructor is only applied if context is not set.

This fixes the issue described at https://github.com/symfony/symfony-docs/pull/10969